### PR TITLE
Scroll Bar should not show unless necessary

### DIFF
--- a/client/components/document/document.module.css
+++ b/client/components/document/document.module.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   min-height: 400px;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .fileNameContainer {


### PR DESCRIPTION
Making a suggestion where the scroll bar should not show on the preview box unless it's truly necessary. Really small change and no biggie if declined. Thank you!