### PR TITLE
Use system theme

### DIFF
--- a/client/components/header/controls.tsx
+++ b/client/components/header/controls.tsx
@@ -8,11 +8,11 @@ import { useTheme } from 'next-themes'
 
 const Controls = () => {
     const [mounted, setMounted] = useState(false)
-    const { theme, setTheme } = useTheme()
+    const { resolvedTheme, setTheme } = useTheme()
     useEffect(() => setMounted(true), [])
     if (!mounted) return null
     const switchThemes = () => {
-        if (theme === 'dark') {
+        if (resolvedTheme === 'dark') {
             setTheme('light')
         } else {
             setTheme('dark')
@@ -26,7 +26,7 @@ const Controls = () => {
                 h="28px"
                 pure
                 onChange={switchThemes}
-                value={theme}
+                value={resolvedTheme}
             >
                 <Select.Option value="light">
                     <span className={styles.selectContent}>

--- a/client/components/header/header.tsx
+++ b/client/components/header/header.tsx
@@ -39,7 +39,7 @@ const Header = () => {
     const { signedIn: isSignedIn, signout } = useSignedIn()
     const userData = useUserData();
     const [pages, setPages] = useState<Tab[]>([])
-    const { setTheme, theme } = useTheme()
+    const { setTheme, resolvedTheme } = useTheme()
 
     useEffect(() => {
         setBodyHidden(expanded)
@@ -63,9 +63,9 @@ const Header = () => {
                 name: isMobile ? "Change theme" : "",
                 onClick: function () {
                     if (typeof window !== 'undefined')
-                        setTheme(theme === 'light' ? 'dark' : 'light');
+                        setTheme(resolvedTheme === 'light' ? 'dark' : 'light');
                 },
-                icon: theme === 'light' ? <MoonIcon /> : <SunIcon />,
+                icon: resolvedTheme === 'light' ? <MoonIcon /> : <SunIcon />,
                 value: "theme",
             }
         ]
@@ -133,7 +133,7 @@ const Header = () => {
         }
         // TODO: investigate deps causing infinite loop 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isMobile, isSignedIn, theme, userData])
+    }, [isMobile, isSignedIn, resolvedTheme, userData])
 
     const onTabChange = useCallback((tab: string) => {
         if (typeof window === 'undefined') return


### PR DESCRIPTION
`next-theme` 's `useTheme` hook returns both `theme` and `resolveTheme` [Docs](https://github.com/pacocoursey/next-themes/blob/master/README.md#usetheme-1).
`theme`, by default returns `'system'`, but we need to use either `"light"` or `"dark"`.
`resolveTheme` does just that.

## Reproduction steps
Previously, when opening Drift in an incognito window (no `theme` setup, so it defaults to `"system"`), the first click on the header theme will do nothing (it will set `theme` to something other than `"system"`).

The background is white, and the icon is a 🌞 
![image](https://user-images.githubusercontent.com/403456/161332639-28b737b3-332f-4049-b881-b9471b759531.png)
