### PR TITLE
`drift_home` already has a default

### DIFF
--- a/server/src/lib/get-database-path.ts
+++ b/server/src/lib/get-database-path.ts
@@ -7,8 +7,7 @@ import config from "./config"
 // This does *not* support `~other_user/tmp` => `/home/other_user/tmp`.
 function getDatabasePath() {
 	const fileName = "drift.sqlite"
-	const databasePath =
-		`${config.drift_home}/${fileName}` || `~/.drift/${fileName}`
+	const databasePath = `${config.drift_home}/${fileName}`
 
 	const home = os.homedir().replace("$", "$$$$")
 	return path.resolve(databasePath.replace(/^~($|\/|\\)/, home + "$1"))


### PR DESCRIPTION
`||` on an exsiting string does nothing ~~useful~~.

https://github.com/MaxLeiter/Drift/blob/1c2fef0ee404c099786d175a507c992a53136c3a/server/src/lib/config.ts#L4