### PR TITLE
Destoy files when destroying post

### DIFF
--- a/server/src/routes/posts.ts
+++ b/server/src/routes/posts.ts
@@ -299,6 +299,11 @@ posts.delete("/:id", jwt, async (req: UserJwtRequest, res, next) => {
 					model: User,
 					as: "users",
 					attributes: ["id"]
+				},
+				{
+					model: File,
+					as: "files",
+					attributes: ["id"]
 				}
 			]
 		})


### PR DESCRIPTION
Fixes #51 though we should consider adding a overarching [transaction](https://sequelize.org/v3/docs/transactions/) over the whole deletion 😸.

The deletion here:
https://github.com/MaxLeiter/Drift/blob/6a6a2a34966a4413bd9ffa16c6033b6e660bb851/server/src/routes/posts.ts#L312-L313

was ok, but `files` key was never set.