### PR TITLE
Add volume mapping for DRIFT_HOME to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,12 @@ services:
       - WELCOME_CONTENT
       - WELCOME_TITLE
       - ENABLE_ADMIN
-      - DRIFT_HOME
+      - DRIFT_HOME=/drift
+    volumes:
+      - drift_data:/drift
     ports:
       - "3000:3000"
+
   client:
     build:
       context: ./client


### PR DESCRIPTION
Important to persist data across container updates. Feel free to rename the path/volume as you see fit.