### PR TITLE
refactor: docker

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,50 +1,21 @@
-FROM node:17-alpine AS deps
+FROM node:18-alpine AS builder
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 
 WORKDIR /app
 
-COPY package.json yarn.lock ./
-
-RUN yarn install --frozen-lockfile
-
-FROM node:17-alpine AS builder
-
-WORKDIR /app
-
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-ARG API_URL
+RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN pnpm install --frozen-lockfile
+
+ARG DATABASE_URL
 
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV API_URL=${API_URL:-http://localhost:3000}
+ENV DATABASE_URL=${DATABASE_URL}
+ENV DRIFT_URL=${DRIFT_URL:-http://localhost:3000}
 
-RUN yarn build
+RUN pnpm prisma && pnpm build
 
-FROM node:17-alpine AS runner
-
-WORKDIR /app
-
-ARG NODE_ENV
-
-ENV NEXT_TELEMETRY_DISABLED=1
-ENV NODE_ENV=${NODE_ENV:-production}
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-COPY --from=builder /app/next.config.mjs ./
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/package.json ./package.json
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-USER nextjs
-
-ENV PORT=3001
-
-EXPOSE 3001
-
-CMD ["node", "server.js"]
+CMD pnpm start

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -2,27 +2,30 @@ services:
   drift:
     build:
       context: ./
+      dockerfile: Dockerfile
+      args:
+        - DATABASE_URL=postgressql://maxleiter:wHaQdWJcZz2pWd0@localhost:5432/postgres
     container_name: drift
     restart: unless-stopped
     user: 1000:1000
     environment:
-      - WELCOME_CONTENT="## Drift is a self-hostable clone of GitHub Gist. \nIt is a simple way to share code and text snippets with your friends, with support for the following:\n  \n  - Render GitHub Extended Markdown (including images)\n  - User authentication\n  - Private, public, and password protected posts\n  - Markdown is rendered and stored on the server\n  - Syntax highlighting and automatic language detection\n  - Drag-and-drop file uploading\n\n  If you want to signup, you can join at [/signup](/signup) as long as you have a passcode provided by the administrator (which you don\'t need for this demo). **This demo is on a memory-only database, so accounts and pastes can be deleted at any time.** \n\nYou can find the source code on [GitHub](https://github.com/MaxLeiter/drift)."
-      - WELCOME_TITLE="Drift"
-      - REGISTRATION_PASSWORD=""
+      - WELCOME_CONTENT=## Drift is a self-hostable clone of GitHub Gist. \nIt is a simple way to share code and text snippets with your friends, with support for the following:\n  \n  - Render GitHub Extended Markdown (including images)\n  - User authentication\n  - Private, public, and password protected posts\n  - Markdown is rendered and stored on the server\n  - Syntax highlighting and automatic language detection\n  - Drag-and-drop file uploading\n\n  If you want to signup, you can join at [/signup](/signup) as long as you have a passcode provided by the administrator (which you don\'t need for this demo). **This demo is on a memory-only database, so accounts and pastes can be deleted at any time.** \n\nYou can find the source code on [GitHub](https://github.com/MaxLeiter/drift).
+      - WELCOME_TITLE=Drift
+      - REGISTRATION_PASSWORD=
       - NEXTAUTH_URL=http://localhost:3000
       - NEXTAUTH_SECRET=secret
       - GITHUB_CLIENT_ID=64100c941c2474a5698a
       - GITHUB_CLIENT_SECRET=cf4c1d510741a439c77d0593e36469d234eca894
-      - DATABASE_URL=postgressql://maxleiter:wHaQdWJcZz2pWd0@postgres:5432/postgres
       - DRIFT_URL=http://localhost:3000
     ports:
       - "3000:3000"
-    volumes:
-      - ./drift:/app
+    networks:
+      - drift_network
     depends_on:
       - postgres
+
   postgres:
-    image: postgres:13
+    image: postgres:15
     container_name: postgres
     restart: unless-stopped
     user: 1000:1000
@@ -30,5 +33,13 @@ services:
       - POSTGRES_PASSWORD=wHaQdWJcZz2pWd0
       - POSTGRES_USER=maxleiter
       - POSTGRES_DB=postgres
+    ports:
+      - 5432:5432
     volumes:
       - ./postgres:/var/lib/postgresql/data
+    networks:
+      - drift_network
+
+networks:
+  drift_network:
+    external: true


### PR DESCRIPTION
this is the basic refactor of the docker stuffs for drift. there are things that still need to be fleshed out like:

- [ ] [ignoring build errors](c794c1a8abd908a6f9bae554fce6c0c99144006b) 
- [ ] properly handling the [prisma command](a6e57f85fd6be3c4be50c311e0f888540c471759)
- [ ] the issue of image size(~2GB) due to bundling `node_modules`. to slim it down it would need to use the next standalone build tool: https://nextjs.org/docs/advanced-features/output-file-tracing#automatically-copying-traced-files

this needs testing with auth providers as the example is what was in the compose originally. if you run the db on the same host as drift you will need to manually make a docker network for them to communicate as the compose file cant do that for you.